### PR TITLE
75 - Deny permission automatically appears for any new pages created …

### DIFF
--- a/DesktopModules/Vanjaro/UXManager/Extensions/Menu/Pages/Managers/PagesManager.cs
+++ b/DesktopModules/Vanjaro/UXManager/Extensions/Menu/Pages/Managers/PagesManager.cs
@@ -390,7 +390,7 @@ namespace Vanjaro.UXManager.Extensions.Menu.Pages
                         };
 
                         rolepermission.Permissions.Clear();
-                        foreach (Permission item in RolePerm.Permissions)
+                        foreach (Permission item in RolePerm.Permissions.Where(x => x.AllowAccess))
                         {
                             Dnn.PersonaBar.Library.DTO.Permission permission = new Dnn.PersonaBar.Library.DTO.Permission
                             {
@@ -399,7 +399,6 @@ namespace Vanjaro.UXManager.Extensions.Menu.Pages
                                 View = item.View,
                                 AllowAccess = item.AllowAccess
                             };
-
                             rolepermission.Permissions.Add(permission);
                         }
 


### PR DESCRIPTION
#75  Deny permission automatically appears for any new pages created in Vanjaro that prohibits authenticated users from viewing pages normally visible to everyone.