### PR TITLE
Templates are broken in case of a website template type is blank.

### DIFF
--- a/DesktopModules/Vanjaro/Core/Library/Managers/SettingManager.cs
+++ b/DesktopModules/Vanjaro/Core/Library/Managers/SettingManager.cs
@@ -234,6 +234,10 @@ namespace Vanjaro.Core
                 UserInfo uInfo = UserController.Instance.GetCurrentUserInfo();
 
                 IFolderInfo fi = FolderManager.Instance.GetFolder(pinfo.PortalID, "Images/");
+                if (fi == null)
+                {
+                    fi = FolderManager.Instance.AddFolder(pinfo.PortalID, "Images/");
+                }
 
                 #region Copy Vthemes in portal folder
 


### PR DESCRIPTION
Closes #329 Templates are broken in cases of a website template type is blank.
