### PR TITLE
#1577 - Icon component break in link block while copying

### DIFF
--- a/DesktopModules/Vanjaro/UXManager/Library/Resources/Scripts/Blocks/link.js
+++ b/DesktopModules/Vanjaro/UXManager/Library/Resources/Scripts/Blocks/link.js
@@ -80,6 +80,12 @@
 					}
 				}
 			}),
-		view: linkView
+		view: linkView.extend({
+			events: {
+				dblclick: function () {
+					return false;
+				}
+			}
+		}),
 	});
 }


### PR DESCRIPTION
Closes #1577 