### PR TITLE
Make third party module link color white in edit mode

### DIFF
--- a/DesktopModules/Vanjaro/UXManager/Library/Resources/Scripts/GrapesJsManagers/css/uxmanager.css
+++ b/DesktopModules/Vanjaro/UXManager/Library/Resources/Scripts/GrapesJsManagers/css/uxmanager.css
@@ -3689,7 +3689,7 @@ body .gjs-selected {
 }
 
 .app-link {
-    color: #a4afb7;
+    color: #fff;
 }
 
 .app-header + #vjEditor {


### PR DESCRIPTION
Make third-party module link color white in edit mode
close #1655 